### PR TITLE
fix prerender error for useSearchParams in code-verify, adding Suspense

### DIFF
--- a/src/app/auth/verify-code/page.tsx
+++ b/src/app/auth/verify-code/page.tsx
@@ -8,5 +8,9 @@ import { config } from '@/config';
 export const metadata = { title: `Ввести код | ${config.site.name}` } satisfies Metadata;
 
 export default function Page(): React.JSX.Element {
-  return <VerifyCodeForm />;
+  return (
+    <React.Suspense fallback="...Загрузка">
+      <VerifyCodeForm />
+    </React.Suspense>
+  );
 }


### PR DESCRIPTION
пофиксил prerender error

```Generating static pages (0/11)  [==  ] ⨯ useSearchParams() should be wrapped in a suspense boundary at page "/auth/verify-code". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout```