### PR TITLE
add tournaments api + page tournament-item + page tournament-edit

### DIFF
--- a/src/app/dashboard/tournaments/[id]/edit/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/edit/page.tsx
@@ -1,0 +1,27 @@
+import { Metadata, NextPage } from 'next';
+
+import { Stack } from '@mui/material';
+
+import TournamentEditForm from '@/components/dashboard/tournaments/edit/tournament-edit-form';
+import BackToLink from '@/components/ui/back-to-link';
+import { config } from '@/config';
+import { paths } from '@/paths';
+
+export const metadata = { title: `Редактировать турнир | ${config.site.name}` } satisfies Metadata;
+
+const title = 'Редактирование турнира';
+
+interface Params {
+  id: string;
+}
+
+const Page: NextPage<{ params: Params }> = ({ params }) => {
+  return (
+    <Stack spacing={2}>
+      <BackToLink text="Вернуться к списку турниров" href={paths.dashboard.tournaments.index} />
+      <TournamentEditForm title={title} id={params.id} />
+    </Stack>
+  );
+};
+
+export default Page;

--- a/src/app/dashboard/tournaments/new/page.tsx
+++ b/src/app/dashboard/tournaments/new/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+
+import * as React from 'react';
+
+import { Stack } from '@mui/material';
+
+import TournamentEditForm from '@/components/dashboard/tournaments/edit/tournament-edit-form';
+import BackToLink from '@/components/ui/back-to-link';
+import { config } from '@/config';
+import { paths } from '@/paths';
+
+export const metadata = { title: `Создать турнир | ${config.site.name}` } satisfies Metadata;
+
+const title = 'Создание турнира';
+
+export default function Page(): React.JSX.Element {
+  return (
+    <Stack spacing={2}>
+      <BackToLink text="Вернуться к списку турниров" href={paths.dashboard.tournaments.index} />
+      <TournamentEditForm title={title} />
+    </Stack>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -36,7 +36,7 @@ export default function Page(): React.JSX.Element {
         >
           <Typography variant="h1">Страница не найдена</Typography>
           <Typography variant="subtitle1">Но есть другие полезные страницы</Typography>
-          <BackToLink text="На главную" href={paths.dashboard.tournaments} />
+          <BackToLink text="На главную" href={paths.dashboard.tournaments.index} />
         </Stack>
       </Container>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,5 +3,5 @@ import { redirect } from 'next/navigation';
 import { paths } from '@/paths';
 
 export default function Page(): never {
-  redirect(paths.dashboard.tournaments);
+  redirect(paths.dashboard.tournaments.index);
 }

--- a/src/components/dashboard/layout/config.ts
+++ b/src/components/dashboard/layout/config.ts
@@ -6,7 +6,7 @@ export const navItems: NavItemConfig[] = [
   {
     key: 'tournaments',
     title: 'Турниры',
-    href: paths.dashboard.tournaments,
+    href: paths.dashboard.tournaments.index,
     icon: NavIconNames.trophy,
   },
   { key: 'teams', title: 'Команды', href: paths.dashboard.teams.index, icon: NavIconNames.users },

--- a/src/components/dashboard/teams/constants.ts
+++ b/src/components/dashboard/teams/constants.ts
@@ -2,8 +2,6 @@ import { z as zod } from 'zod';
 
 import { PlayerEditFormData } from './types';
 
-export const MAX_FILE_SIZE = 2 * 1024 * 1024;
-
 export const MAX_PLAYER_FIO_LENGTH = 50;
 
 export const playerEditFormSchema = zod.object({

--- a/src/components/dashboard/teams/constants.ts
+++ b/src/components/dashboard/teams/constants.ts
@@ -1,9 +1,8 @@
 import { z as zod } from 'zod';
 
-import { PlayerEditFormData } from '../types';
+import { PlayerEditFormData } from './types';
 
 export const MAX_FILE_SIZE = 2 * 1024 * 1024;
-export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png'];
 
 export const MAX_PLAYER_FIO_LENGTH = 50;
 

--- a/src/components/dashboard/teams/edit/player-edit-form.tsx
+++ b/src/components/dashboard/teams/edit/player-edit-form.tsx
@@ -11,7 +11,7 @@ import { DatePicker } from '@mui/x-date-pickers';
 
 import FileInput from '@/components/ui/file-input';
 import { ACCEPTED_IMAGE_TYPES } from '@/constants';
-import { useUploadFileMutation } from '@/lib/store/features/file-api';
+import { useUploadFile } from '@/hooks/use-upload-file';
 
 import { MAX_PLAYER_FIO_LENGTH, playerEditFormSchema } from '../constants';
 import { PlayerEditFormData } from '../types';
@@ -26,7 +26,7 @@ type TeamPlayersEditFormProps = {
 };
 
 const TeamPlayerEditForm = React.memo(({ item, onSave, isLoading }: TeamPlayersEditFormProps) => {
-  const [uploadFile] = useUploadFileMutation();
+  const handleUploadFile = useUploadFile();
 
   const methods = useForm<PlayerEditFormData>({
     mode: 'all',
@@ -35,14 +35,6 @@ const TeamPlayerEditForm = React.memo(({ item, onSave, isLoading }: TeamPlayersE
   });
 
   React.useEffect(() => methods.reset(item), [methods, item]);
-
-  const handleUploadFile = async (file: File) => {
-    try {
-      const { url } = await uploadFile(file).unwrap();
-
-      return url;
-    } catch {}
-  };
 
   return (
     <form onSubmit={methods.handleSubmit(onSave)}>

--- a/src/components/dashboard/teams/edit/player-edit-form.tsx
+++ b/src/components/dashboard/teams/edit/player-edit-form.tsx
@@ -10,10 +10,11 @@ import { Button, Unstable_Grid2 as Grid, Stack, TextField } from '@mui/material'
 import { DatePicker } from '@mui/x-date-pickers';
 
 import FileInput from '@/components/ui/file-input';
+import { ACCEPTED_IMAGE_TYPES } from '@/constants';
 import { useUploadFileMutation } from '@/lib/store/features/file-api';
 
+import { MAX_PLAYER_FIO_LENGTH, playerEditFormSchema } from '../constants';
 import { PlayerEditFormData } from '../types';
-import { ACCEPTED_IMAGE_TYPES, MAX_PLAYER_FIO_LENGTH, playerEditFormSchema } from './constants';
 
 const MIN_BIRTH_DATE = new Date('1900-12-01');
 const MAX_BIRTH_DATE = new Date();

--- a/src/components/dashboard/teams/edit/players-table-edit-form.tsx
+++ b/src/components/dashboard/teams/edit/players-table-edit-form.tsx
@@ -24,8 +24,8 @@ import { styled, useTheme } from '@mui/material/styles';
 
 import formatDate from '@/lib/format-date';
 
+import { DEFAULT_INITIAL_VALUES_PLAYER } from '../constants';
 import { PlayerEditFormData } from '../types';
-import { DEFAULT_INITIAL_VALUES_PLAYER } from './constants';
 import TeamPlayerEditForm from './player-edit-form';
 
 type TeamPlayersEditFormProps = {

--- a/src/components/dashboard/teams/edit/settings-edit-form.tsx
+++ b/src/components/dashboard/teams/edit/settings-edit-form.tsx
@@ -11,10 +11,11 @@ import { Avatar, Box, Button, Unstable_Grid2 as Grid, Stack, TextField } from '@
 
 import FileInput from '@/components/ui/file-input';
 import { SkeletonList } from '@/components/ui/list';
+import { ACCEPTED_IMAGE_TYPES } from '@/constants';
 import { useUploadFileMutation } from '@/lib/store/features/file-api';
 
+import { MAX_TEAM_NAME_LENGTH, teamEditFormSchema } from '../constants';
 import { TeamEditFormData } from '../types';
-import { ACCEPTED_IMAGE_TYPES, MAX_TEAM_NAME_LENGTH, teamEditFormSchema } from './constants';
 
 const DEFAULT_INITIAL_VALUES: TeamEditFormData = {
   title: '',

--- a/src/components/dashboard/teams/edit/settings-edit-form.tsx
+++ b/src/components/dashboard/teams/edit/settings-edit-form.tsx
@@ -12,7 +12,7 @@ import { Avatar, Box, Button, Unstable_Grid2 as Grid, Stack, TextField } from '@
 import FileInput from '@/components/ui/file-input';
 import { SkeletonList } from '@/components/ui/list';
 import { ACCEPTED_IMAGE_TYPES } from '@/constants';
-import { useUploadFileMutation } from '@/lib/store/features/file-api';
+import { useUploadFile } from '@/hooks/use-upload-file';
 
 import { MAX_TEAM_NAME_LENGTH, teamEditFormSchema } from '../constants';
 import { TeamEditFormData } from '../types';
@@ -29,7 +29,7 @@ type TeamSettingsEditFormProps = {
 
 const TeamSettingsEditForm = React.memo(
   ({ team = DEFAULT_INITIAL_VALUES, isLoading, onSave }: TeamSettingsEditFormProps) => {
-    const [uploadFile] = useUploadFileMutation();
+    const handleUploadFile = useUploadFile();
 
     const methods = useForm<TeamEditFormData>({
       mode: 'all',
@@ -42,14 +42,6 @@ const TeamSettingsEditForm = React.memo(
     if (isLoading) {
       return <SkeletonList />;
     }
-
-    const handleUploadFile = async (file: File) => {
-      try {
-        const { url } = await uploadFile(file).unwrap();
-
-        return url;
-      } catch {}
-    };
 
     return (
       <FormProvider {...methods}>

--- a/src/components/dashboard/teams/edit/team-tabs-edit-form.tsx
+++ b/src/components/dashboard/teams/edit/team-tabs-edit-form.tsx
@@ -11,6 +11,7 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import { Card, CardContent, Stack, Tab, Tabs, Typography } from '@mui/material';
 
 import { useAsyncRoutePush } from '@/hooks/use-async-route';
+import formatDateToISO from '@/lib/format-date-to-ISO';
 import { useSavePlayerMutation } from '@/lib/store/features/players-api';
 import { useGetTeamByIdQuery, useSaveTeamMutation } from '@/lib/store/features/teams-api';
 import { paths } from '@/paths';
@@ -42,7 +43,7 @@ const getPlayersValues = (players?: PlayerDTO[]): PlayerEditFormData[] => {
 
 const preparePlayerDataForSave = (values: PlayerEditFormData): PlayerDTO => ({
   ...values,
-  bDay: values.bDay ? values.bDay.toISOString() : '',
+  bDay: formatDateToISO(values.bDay),
 });
 
 const TabsTeamEditForm = React.memo(({ id, title }: TabsTeamEditFormProps) => {

--- a/src/components/dashboard/teams/types.ts
+++ b/src/components/dashboard/teams/types.ts
@@ -1,6 +1,6 @@
 import { z as zod } from 'zod';
 
-import { playerEditFormSchema, teamEditFormSchema } from './edit/constants';
+import { playerEditFormSchema, teamEditFormSchema } from './constants';
 
 export type TeamEditFormData = zod.input<typeof teamEditFormSchema>;
 

--- a/src/components/dashboard/tournaments/constants.ts
+++ b/src/components/dashboard/tournaments/constants.ts
@@ -1,7 +1,5 @@
 import { z as zod } from 'zod';
 
-export const MAX_FILE_SIZE = 2 * 1024 * 1024;
-
 export const MAX_TOURNAMENT_TITLE_LENGTH = 50;
 
 const dateSchema = zod.date({

--- a/src/components/dashboard/tournaments/constants.ts
+++ b/src/components/dashboard/tournaments/constants.ts
@@ -1,0 +1,62 @@
+import { z as zod } from 'zod';
+
+export const MAX_FILE_SIZE = 2 * 1024 * 1024;
+
+export const MAX_TOURNAMENT_TITLE_LENGTH = 50;
+
+const dateSchema = zod.date({
+  errorMap: (issue, { defaultError }) => {
+    if (issue.code === 'invalid_date') {
+      return {
+        message: 'Некорректный формат даты',
+      };
+    }
+
+    if (issue.code === 'invalid_type') {
+      return {
+        message: 'Укажите дату',
+      };
+    }
+
+    return {
+      message: defaultError,
+    };
+  },
+});
+
+export const tournamentEditFormSchema = zod
+  .object({
+    id: zod.coerce.number().optional(),
+    title: zod
+      .string()
+      .min(1, { message: 'Обязательно' })
+      .min(3, { message: 'Минимум 3 символа' })
+      .max(MAX_TOURNAMENT_TITLE_LENGTH, {
+        message: `Максимум ${MAX_TOURNAMENT_TITLE_LENGTH} символов`,
+      }),
+    logoUrl: zod.string().optional(),
+    startDate: dateSchema,
+    endDate: dateSchema,
+    registerStartDate: dateSchema.nullable(),
+    registerEndDate: dateSchema.nullable(),
+  })
+  .refine((data) => !data.startDate || !data.endDate || data.startDate <= data.endDate, {
+    path: ['endDate'],
+    message: 'Дата должна быть позже начала турнира',
+  })
+  .refine(
+    (data) =>
+      !data.registerStartDate || !data.registerEndDate || data.registerStartDate <= data.endDate,
+    {
+      path: ['registerEndDate'],
+      message: 'Дата должна быть позже начала регистрации турнира',
+    },
+  )
+  .refine((data) => data.registerStartDate || !data.registerEndDate, {
+    path: ['registerStartDate'],
+    message: 'Укажите дату начала регистрации',
+  })
+  .refine((data) => !data.registerStartDate || data.registerEndDate, {
+    path: ['registerEndDate'],
+    message: 'Укажите дату завершения регистрации',
+  });

--- a/src/components/dashboard/tournaments/edit/tournament-edit-form.tsx
+++ b/src/components/dashboard/tournaments/edit/tournament-edit-form.tsx
@@ -20,11 +20,12 @@ import {
 import { DatePicker } from '@mui/x-date-pickers';
 
 import FileInput from '@/components/ui/file-input';
+import { SkeletonList } from '@/components/ui/list';
 import { ACCEPTED_IMAGE_TYPES } from '@/constants';
 import { useAsyncRoutePush } from '@/hooks/use-async-route';
+import { useUploadFile } from '@/hooks/use-upload-file';
 import formatDateToISO from '@/lib/format-date-to-ISO';
 import parseDateFromISO from '@/lib/parse-date-from-ISO';
-import { useUploadFileMutation } from '@/lib/store/features/file-api';
 import {
   useGetTournamentByIdQuery,
   useSaveTournamentMutation,
@@ -38,8 +39,6 @@ type TournamentEditFormProps = {
   id?: string;
   title: string;
 };
-
-const MIN_DATE = new Date();
 
 const getTournamentValues = (tournament?: TournamentDTO): TournamentEditFormData => {
   if (!tournament) {
@@ -72,7 +71,7 @@ const prepareTournamentDataForSave = (values: TournamentEditFormData): Tournamen
 const TournamentEditForm = React.memo(({ id, title }: TournamentEditFormProps) => {
   const asyncRouterPush = useAsyncRoutePush();
 
-  const [uploadFile] = useUploadFileMutation();
+  const handleUploadFile = useUploadFile();
 
   const { data: tournament, isLoading: isGetLoading } = useGetTournamentByIdQuery(id ?? skipToken);
   const [saveTournament, { isLoading: isSaveTournamentLoading }] = useSaveTournamentMutation();
@@ -114,16 +113,12 @@ const TournamentEditForm = React.memo(({ id, title }: TournamentEditFormProps) =
 
   React.useEffect(() => methods.reset(getTournamentValues(tournament)), [methods, tournament]);
 
-  const handleUploadFile = async (file: File) => {
-    try {
-      const { url } = await uploadFile(file).unwrap();
-
-      return url;
-    } catch {}
-  };
-
   const startDate = methods.watch('startDate');
   const registerStartDate = methods.watch('registerStartDate');
+
+  if (isLoading) {
+    return <SkeletonList />;
+  }
 
   return (
     <>
@@ -184,7 +179,6 @@ const TournamentEditForm = React.memo(({ id, title }: TournamentEditFormProps) =
                         <DatePicker
                           {...field}
                           label="Начало турнира"
-                          minDate={MIN_DATE}
                           slotProps={{
                             textField: {
                               fullWidth: true,
@@ -226,7 +220,6 @@ const TournamentEditForm = React.memo(({ id, title }: TournamentEditFormProps) =
                         <DatePicker
                           {...field}
                           label="Начало регистрации на турнир"
-                          minDate={MIN_DATE}
                           maxDate={startDate || new Date()}
                           slotProps={{
                             textField: {

--- a/src/components/dashboard/tournaments/edit/tournament-edit-form.tsx
+++ b/src/components/dashboard/tournaments/edit/tournament-edit-form.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import * as React from 'react';
+import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-toastify';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { skipToken } from '@reduxjs/toolkit/query';
+
+import {
+  Avatar,
+  Button,
+  Card,
+  CardContent,
+  Unstable_Grid2 as Grid,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers';
+
+import FileInput from '@/components/ui/file-input';
+import { ACCEPTED_IMAGE_TYPES } from '@/constants';
+import { useAsyncRoutePush } from '@/hooks/use-async-route';
+import formatDateToISO from '@/lib/format-date-to-ISO';
+import parseDateFromISO from '@/lib/parse-date-from-ISO';
+import { useUploadFileMutation } from '@/lib/store/features/file-api';
+import {
+  useGetTournamentByIdQuery,
+  useSaveTournamentMutation,
+} from '@/lib/store/features/tournaments-api';
+import { paths } from '@/paths';
+
+import { MAX_TOURNAMENT_TITLE_LENGTH, tournamentEditFormSchema } from '../constants';
+import { TournamentDTO, TournamentEditFormData } from '../types';
+
+type TournamentEditFormProps = {
+  id?: string;
+  title: string;
+};
+
+const MIN_DATE = new Date();
+
+const getTournamentValues = (tournament?: TournamentDTO): TournamentEditFormData => {
+  if (!tournament) {
+    return {
+      title: '',
+      startDate: new Date(),
+      endDate: new Date(),
+      registerStartDate: null,
+      registerEndDate: null,
+    };
+  }
+
+  return {
+    ...tournament,
+    startDate: new Date(tournament.startDate),
+    endDate: new Date(tournament.endDate),
+    registerStartDate: parseDateFromISO(tournament.registerStartDate),
+    registerEndDate: parseDateFromISO(tournament.registerEndDate),
+  };
+};
+
+const prepareTournamentDataForSave = (values: TournamentEditFormData): TournamentDTO => ({
+  ...values,
+  startDate: formatDateToISO(values.startDate),
+  endDate: formatDateToISO(values.endDate),
+  registerStartDate: formatDateToISO(values.registerStartDate),
+  registerEndDate: formatDateToISO(values.registerEndDate),
+});
+
+const TournamentEditForm = React.memo(({ id, title }: TournamentEditFormProps) => {
+  const asyncRouterPush = useAsyncRoutePush();
+
+  const [uploadFile] = useUploadFileMutation();
+
+  const { data: tournament, isLoading: isGetLoading } = useGetTournamentByIdQuery(id ?? skipToken);
+  const [saveTournament, { isLoading: isSaveTournamentLoading }] = useSaveTournamentMutation();
+
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const handleSaveSettings: SubmitHandler<TournamentEditFormData> = React.useCallback(
+    async (values) => {
+      try {
+        setIsSubmitting(true);
+
+        const result = await saveTournament(prepareTournamentDataForSave(values)).unwrap();
+
+        if (result) {
+          if (!id) {
+            await asyncRouterPush(`${paths.dashboard.tournaments.index}/${result.id}/edit`);
+            toast.success(`Турнир ${result.title} создан!`);
+          } else {
+            toast.success(`Данные турнира ${result.title} сохранены!`);
+          }
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [asyncRouterPush, id, saveTournament],
+  );
+
+  const isLoading = React.useMemo(
+    () => isGetLoading || isSaveTournamentLoading || isSubmitting,
+    [isGetLoading, isSaveTournamentLoading, isSubmitting],
+  );
+
+  const methods = useForm<TournamentEditFormData>({
+    mode: 'all',
+    defaultValues: getTournamentValues(tournament),
+    resolver: zodResolver(tournamentEditFormSchema),
+  });
+
+  React.useEffect(() => methods.reset(getTournamentValues(tournament)), [methods, tournament]);
+
+  const handleUploadFile = async (file: File) => {
+    try {
+      const { url } = await uploadFile(file).unwrap();
+
+      return url;
+    } catch {}
+  };
+
+  const startDate = methods.watch('startDate');
+  const registerStartDate = methods.watch('registerStartDate');
+
+  return (
+    <>
+      <Stack>
+        <Typography variant="h4" sx={{ flex: '1 1 auto' }}>
+          {title}
+        </Typography>
+      </Stack>
+      <Card>
+        <CardContent>
+          <FormProvider {...methods}>
+            <form onSubmit={methods.handleSubmit(handleSaveSettings)}>
+              <Stack spacing={3}>
+                <Controller
+                  control={methods.control}
+                  name="title"
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      helperText={fieldState.error?.message}
+                      error={fieldState.invalid}
+                      label="Название турнира"
+                      fullWidth
+                      inputProps={{ maxLength: MAX_TOURNAMENT_TITLE_LENGTH }}
+                    />
+                  )}
+                />
+                <Controller
+                  name="logoUrl"
+                  control={methods.control}
+                  render={({ field, fieldState }) => (
+                    <Grid container spacing={2} sx={{ justifyContent: 'space-between' }}>
+                      <Grid md={10} sm={9} xs={12} display="grid">
+                        <FileInput
+                          {...field}
+                          onUnload={handleUploadFile}
+                          label="Логотип"
+                          inputProps={{ accept: ACCEPTED_IMAGE_TYPES }}
+                        />
+                      </Grid>
+                      <Grid>
+                        {!fieldState.error && field.value && (
+                          <Avatar
+                            src={field.value}
+                            sx={{ height: 100, width: 100, boxShadow: 3 }}
+                          />
+                        )}
+                      </Grid>
+                    </Grid>
+                  )}
+                />
+                <Grid container spacing={2} sx={{ justifyContent: 'space-between' }}>
+                  <Grid sm={6} xs={12} display="grid">
+                    <Controller
+                      control={methods.control}
+                      name="startDate"
+                      render={({ field, fieldState }) => (
+                        <DatePicker
+                          {...field}
+                          label="Начало турнира"
+                          minDate={MIN_DATE}
+                          slotProps={{
+                            textField: {
+                              fullWidth: true,
+                              error: fieldState.invalid,
+                              helperText: fieldState.error?.message,
+                            },
+                          }}
+                        />
+                      )}
+                    />
+                  </Grid>
+                  <Grid sm={6} xs={12} display="grid">
+                    <Controller
+                      control={methods.control}
+                      name="endDate"
+                      render={({ field, fieldState }) => (
+                        <DatePicker
+                          {...field}
+                          label="Конец турнира"
+                          minDate={startDate || new Date()}
+                          slotProps={{
+                            textField: {
+                              fullWidth: true,
+                              error: fieldState.invalid,
+                              helperText: fieldState.error?.message,
+                            },
+                          }}
+                        />
+                      )}
+                    />
+                  </Grid>
+                </Grid>
+                <Grid container spacing={2} sx={{ justifyContent: 'space-between' }}>
+                  <Grid sm={6} xs={12} display="grid">
+                    <Controller
+                      control={methods.control}
+                      name="registerStartDate"
+                      render={({ field, fieldState }) => (
+                        <DatePicker
+                          {...field}
+                          label="Начало регистрации на турнир"
+                          minDate={MIN_DATE}
+                          maxDate={startDate || new Date()}
+                          slotProps={{
+                            textField: {
+                              fullWidth: true,
+                              error: fieldState.invalid,
+                              helperText: fieldState.error?.message,
+                            },
+                          }}
+                        />
+                      )}
+                    />
+                  </Grid>
+                  <Grid sm={6} xs={12} display="grid">
+                    <Controller
+                      control={methods.control}
+                      name="registerEndDate"
+                      render={({ field, fieldState }) => (
+                        <DatePicker
+                          {...field}
+                          label="Конец регистрации на турнир"
+                          minDate={registerStartDate || new Date()}
+                          maxDate={startDate || new Date()}
+                          slotProps={{
+                            textField: {
+                              fullWidth: true,
+                              error: fieldState.invalid,
+                              helperText: fieldState.error?.message,
+                            },
+                          }}
+                        />
+                      )}
+                    />
+                  </Grid>
+                </Grid>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  sx={{ width: 'max-content', ml: 'auto' }}
+                  disabled={isLoading}
+                >
+                  Сохранить
+                </Button>
+              </Stack>
+            </form>
+          </FormProvider>
+        </CardContent>
+      </Card>
+    </>
+  );
+});
+
+export default TournamentEditForm;

--- a/src/components/dashboard/tournaments/tournament-item.tsx
+++ b/src/components/dashboard/tournaments/tournament-item.tsx
@@ -18,7 +18,7 @@ interface TournamentProps {
 const FORMAT_DATE = 'd MMMM yyyy';
 
 const DateTimePeriod = React.memo(
-  ({ startDate, endDate }: { startDate: string; endDate: string }) => {
+  ({ startDate, endDate }: { startDate?: string; endDate?: string }) => {
     return (
       <Typography color="text.secondary" variant="caption">
         {startDate && formatDate(parseISO(startDate), { format: FORMAT_DATE })}
@@ -32,7 +32,10 @@ const DateTimePeriod = React.memo(
 const TournamentItem = React.memo(({ item }: TournamentProps): React.JSX.Element => {
   return (
     <Card sx={{ display: 'flex' }}>
-      <CardActionArea component={NextLink} href={paths.dashboard.tournaments}>
+      <CardActionArea
+        component={NextLink}
+        href={`${paths.dashboard.tournaments.index}/${item.id}/edit`}
+      >
         <CardMedia
           sx={{ height: { xs: 100, sm: 200 }, display: 'flex', backgroundSize: 'contain' }}
           image={item.logoUrl}
@@ -47,10 +50,14 @@ const TournamentItem = React.memo(({ item }: TournamentProps): React.JSX.Element
               Продолжительность:
             </Typography>
             <DateTimePeriod startDate={item.startDate} endDate={item.endDate} />
-            <Typography color="text.secondary" variant="subtitle2">
-              Регистрация:
-            </Typography>
-            <DateTimePeriod startDate={item.registerStartDate} endDate={item.registerEndDate} />
+            {(item.registerStartDate || item.registerEndDate) && (
+              <>
+                <Typography color="text.secondary" variant="subtitle2">
+                  Регистрация:
+                </Typography>
+                <DateTimePeriod startDate={item.registerStartDate} endDate={item.registerEndDate} />
+              </>
+            )}
           </Stack>
         </CardContent>
       </CardActionArea>

--- a/src/components/dashboard/tournaments/tournaments-list.tsx
+++ b/src/components/dashboard/tournaments/tournaments-list.tsx
@@ -1,11 +1,16 @@
 'use client';
 
+import NextLink from 'next/link';
+
 import * as React from 'react';
 
-import { Unstable_Grid2 as Grid, Pagination, Stack } from '@mui/material';
+import { Plus as PlusIcon } from '@phosphor-icons/react/dist/ssr/Plus';
+
+import { Button, Unstable_Grid2 as Grid, Pagination, Stack } from '@mui/material';
 
 import { ListHeader, ListNoData, SkeletonList } from '@/components/ui/list';
 import { useGetTournamentsQuery } from '@/lib/store/features/tournaments-api';
+import { paths } from '@/paths';
 
 import TournamentItem from './tournament-item';
 
@@ -35,6 +40,15 @@ const TournamentsList = React.memo((): React.JSX.Element => {
     <Stack spacing={3}>
       <Stack direction="row" spacing={3}>
         <ListHeader text="Турниры" />
+        <Button
+          component={NextLink}
+          href={paths.dashboard.tournaments.new}
+          startIcon={<PlusIcon fontSize="var(--icon-fontSize-md)" />}
+          variant="contained"
+          disabled={isLoading}
+        >
+          {isEmptyList ? 'Создать' : 'Добавить'}
+        </Button>
       </Stack>
       {isLoading && <SkeletonList />}
       {!isLoading && isEmptyList && <ListNoData />}

--- a/src/components/dashboard/tournaments/types.ts
+++ b/src/components/dashboard/tournaments/types.ts
@@ -1,9 +1,17 @@
+import { z as zod } from 'zod';
+
+import { tournamentEditFormSchema } from './constants';
+
 export type Tournament = {
   id: number;
-  endDate: string;
-  logoUrl: string;
-  registerEndDate: string;
-  registerStartDate: string;
-  startDate: string;
   title: string;
+  startDate: string;
+  endDate: string;
+  logoUrl?: string;
+  registerStartDate?: string;
+  registerEndDate?: string;
 };
+
+export type TournamentDTO = Omit<Tournament, 'id'> & { id?: Tournament['id'] };
+
+export type TournamentEditFormData = zod.input<typeof tournamentEditFormSchema>;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png'];
+export const MAX_FILE_SIZE = 2 * 1024 * 1024;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,1 @@
-export const shouldNotForwardPropsWithKeys =
-  <CustomProps>(props: Array<keyof CustomProps>) =>
-  (propName: PropertyKey): boolean =>
-    !props.map((p) => p.toString()).includes(propName.toString());
+export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png'];

--- a/src/hooks/use-upload-file.ts
+++ b/src/hooks/use-upload-file.ts
@@ -1,0 +1,23 @@
+import { toast } from 'react-toastify';
+
+import { ACCEPTED_IMAGE_TYPES, MAX_FILE_SIZE } from '@/constants';
+import { useUploadFileMutation } from '@/lib/store/features/file-api';
+
+export const useUploadFile = () => {
+  const [uploadFile] = useUploadFileMutation();
+
+  const handleUploadFile = async (file: File) => {
+    try {
+      const { url } = await uploadFile(file).unwrap();
+
+      return url;
+    } catch {
+      toast.info(`MAX размер файла: ${MAX_FILE_SIZE / 1024 / 1024}MB
+				Разрешенные форматы: ${ACCEPTED_IMAGE_TYPES.join(', ')}`);
+
+      return '';
+    }
+  };
+
+  return handleUploadFile;
+};

--- a/src/lib/format-date-to-ISO.ts
+++ b/src/lib/format-date-to-ISO.ts
@@ -1,0 +1,3 @@
+const formatDateToISO = (date: Date | null): string => (date ? date.toISOString() : '');
+
+export default formatDateToISO;

--- a/src/lib/parse-date-from-ISO.ts
+++ b/src/lib/parse-date-from-ISO.ts
@@ -1,0 +1,3 @@
+const parseDateFromISO = (date?: string): Date | null => (date ? new Date(date) : null);
+
+export default parseDateFromISO;

--- a/src/lib/store/api.ts
+++ b/src/lib/store/api.ts
@@ -10,6 +10,7 @@ const listenerMiddleware = createListenerMiddleware();
 enum CacheTag {
   TEAMS = 'TEAMS',
   TEAM = 'TEAM',
+  TOURNAMENT = 'TOURNAMENT',
   TOURNAMENTS = 'TOURNAMENTS',
 }
 

--- a/src/lib/store/features/tournaments-api.ts
+++ b/src/lib/store/features/tournaments-api.ts
@@ -35,10 +35,10 @@ export const tournamentsApi = rootApi.injectEndpoints({
       query: (id) => `user/tournaments/${id}`,
       providesTags: (result) => {
         if (!result) {
-          return [CacheTag.TOURNAMENTS];
+          return [CacheTag.TOURNAMENT];
         }
 
-        return [CacheTag.TOURNAMENTS, { id: result.id, type: CacheTag.TOURNAMENTS }];
+        return [CacheTag.TOURNAMENT, { id: result.id, type: CacheTag.TOURNAMENT }];
       },
     }),
     saveTournament: build.mutation<Tournament, TournamentDTO>({
@@ -47,7 +47,7 @@ export const tournamentsApi = rootApi.injectEndpoints({
         url: `user/tournaments/${data.id ?? ''}`,
         body: data,
       }),
-      invalidatesTags: [CacheTag.TOURNAMENTS, CacheTag.TOURNAMENTS],
+      invalidatesTags: [CacheTag.TOURNAMENTS, CacheTag.TOURNAMENT],
     }),
   }),
 });

--- a/src/lib/store/features/tournaments-api.ts
+++ b/src/lib/store/features/tournaments-api.ts
@@ -1,4 +1,4 @@
-import { Tournament } from '@/components/dashboard/tournaments/types';
+import { Tournament, TournamentDTO } from '@/components/dashboard/tournaments/types';
 import { CacheTag, rootApi } from '@/lib/store/api';
 
 export type PaginationTypes = {
@@ -31,7 +31,26 @@ export const tournamentsApi = rootApi.injectEndpoints({
         ];
       },
     }),
+    getTournamentById: build.query<TournamentDTO, number | string | undefined>({
+      query: (id) => `user/tournaments/${id}`,
+      providesTags: (result) => {
+        if (!result) {
+          return [CacheTag.TOURNAMENTS];
+        }
+
+        return [CacheTag.TOURNAMENTS, { id: result.id, type: CacheTag.TOURNAMENTS }];
+      },
+    }),
+    saveTournament: build.mutation<Tournament, TournamentDTO>({
+      query: (data) => ({
+        method: data.id ? 'PUT' : 'POST',
+        url: `user/tournaments/${data.id ?? ''}`,
+        body: data,
+      }),
+      invalidatesTags: [CacheTag.TOURNAMENTS, CacheTag.TOURNAMENTS],
+    }),
   }),
 });
 
-export const { useGetTournamentsQuery } = tournamentsApi;
+export const { useGetTournamentsQuery, useGetTournamentByIdQuery, useSaveTournamentMutation } =
+  tournamentsApi;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -8,6 +8,10 @@ export const paths = {
       new: '/dashboard/teams/new',
       edit: '/dashboard/teams/[id]/edit',
     },
-    tournaments: '/dashboard/tournaments',
+    tournaments: {
+      index: '/dashboard/tournaments',
+      new: '/dashboard/tournaments/new',
+      edit: '/dashboard/tournaments/[id]/edit',
+    },
   },
 } as const;


### PR DESCRIPTION
- добавила связь с беком в турнирах
- добавила страницу с редактированием и созданием
- вынесла ACCEPTED_IMAGE_TYPES на верхний уровень

Выполненные Задачи:
- Страница Турнира
[#12](https://github.com/sportspace-develop/front-next/issues/12)
Страница Турнира с бэком связь
[#31](https://github.com/sportspace-develop/front-next/issues/31)


2 коммит:
- содержит исправления ошибок
- добавила хук useUploadFile чтобы везде одно и тоже не писать
- добавила кнопку add турнир
- убрала MIN_DATE в турнирах чтобы можно было редактировать, иначе там по дефолту текущая дата, а уже завтра она станет вчерашней. пока уберу это ограничение
- добавила уведомление на ошибку, чтобы как нибудь сооретировать пользователя  toast.info(`
				Максимальный размер: ${MAX_FILE_SIZE / 1024 / 1024}mb
				Разрешенные форматы: ${ACCEPTED_IMAGE_TYPES.join(', ')}`);